### PR TITLE
Verify release archive checksums

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -2,12 +2,19 @@ package selfupdate
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
-//lint:ignore U1000 TODO
-func verify(path string) error {
+func verifyChecksum(path, expected string) error {
+	expected = strings.TrimSpace(expected)
+	if expected == "" {
+		return fmt.Errorf("checksum not found")
+	}
+
 	f, err := os.Open(path)
 	if err != nil {
 		return err
@@ -17,6 +24,11 @@ func verify(path string) error {
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
 		return err
+	}
+
+	actual := hex.EncodeToString(h.Sum(nil))
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("checksum mismatch: expected %v, got %v", expected, actual)
 	}
 	return nil
 }

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -1,0 +1,43 @@
+package selfupdate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"testing"
+)
+
+func TestVerifyChecksum(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "archive_*.tar.gz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("archive contents"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256([]byte("archive contents"))
+	if err := verifyChecksum(f.Name(), hex.EncodeToString(sum[:])); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyChecksumMismatch(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "archive_*.tar.gz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("archive contents"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := verifyChecksum(f.Name(), "deadbeef"); err == nil {
+		t.Fatal("expected checksum mismatch")
+	}
+}

--- a/selfupdate.go
+++ b/selfupdate.go
@@ -167,12 +167,15 @@ func (c config) Install(tag, asset string) error {
 		return err
 	}
 
-	// sum, err := c.Checksum(tag, asset)
-	// if err != nil {
-	// 	return err
-	// }
+	sum, err := c.Checksum(tag, asset)
+	if err != nil {
+		return err
+	}
 
-	// TODO verify checksum
+	c.Printf("verifying checksum for %#v\n", asset)
+	if err := verifyChecksum(tmpArchive.Name(), sum); err != nil {
+		return err
+	}
 
 	binDir, err := traverse.GoBinDir(carapace.NewContext())
 	if err != nil {


### PR DESCRIPTION
## Summary
- verify downloaded release archives against the published checksums before extraction
- fail when a checksum entry is missing or does not match
- add unit coverage for successful and mismatched checksum verification

Refs #4

## Validation
- `go test ./...`
- `(cd cmd && go test ./...)`
- `git diff --check`