### PR TITLE
Add implicit selfupdate tag and asset selection

### DIFF
--- a/command.go
+++ b/command.go
@@ -23,17 +23,39 @@ func Command(owner, repository string, opts ...option) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "selfupdate [source] [tag] [asset]",
 		Short: "install nightly/stable releases",
-		Args:  cobra.MinimumNArgs(3), // TODO implicit update to latest
+		Args:  cobra.RangeArgs(1, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 2 { // TODO test
-				opts := append([]option{WithProgress(cmd.ErrOrStderr())}, opts...)
-				if cmd.Flag("force").Changed {
-					opts = append(opts, WithForce(true))
-				}
-				c := New(owner, repo[args[0]], opts...)
-				return c.Install(args[1], args[2])
+			repository, ok := repo[args[0]]
+			if !ok {
+				return fmt.Errorf("invalid source %q", args[0])
 			}
-			return nil
+
+			opts := append([]option{WithProgress(cmd.ErrOrStderr())}, opts...)
+			if cmd.Flag("force").Changed {
+				opts = append(opts, WithForce(true))
+			}
+
+			var tag, asset string
+			if len(args) > 1 {
+				tag = args[1]
+			}
+			if len(args) > 2 {
+				asset = args[2]
+			}
+
+			c := New(owner, repository, opts...)
+			resolvedTag, resolvedAsset, err := c.resolve(tag, asset)
+			if err != nil {
+				return err
+			}
+			if tag == "" {
+				c.Printf("selected tag %#v\n", resolvedTag)
+			}
+			if asset == "" {
+				c.Printf("selected asset %#v\n", resolvedAsset)
+			}
+
+			return c.Install(resolvedTag, resolvedAsset)
 		},
 	}
 
@@ -54,6 +76,9 @@ func Command(owner, repository string, opts ...option) *cobra.Command {
 			if cmd.Flag("all").Changed {
 				opts = append(opts, WithAssetFilter(nil))
 			}
+			if len(c.Args) == 0 {
+				return carapace.ActionMessage("missing source")
+			}
 			tags, err := New(owner, repo[c.Args[0]], opts...).Tags()
 			if err != nil {
 				return carapace.ActionMessage(err.Error())
@@ -64,6 +89,9 @@ func Command(owner, repository string, opts ...option) *cobra.Command {
 			opts = append(opts, WithProgress(io.Discard))
 			if cmd.Flag("all").Changed {
 				opts = append(opts, WithAssetFilter(nil))
+			}
+			if len(c.Args) < 2 {
+				return carapace.ActionMessage("missing tag")
 			}
 			assets, err := New(owner, repo[c.Args[0]], opts...).Assets(c.Args[1])
 			if err != nil {

--- a/selfupdate.go
+++ b/selfupdate.go
@@ -121,6 +121,32 @@ func (c config) Tags() ([]string, error) {
 	return names, nil
 }
 
+func (c config) resolve(tag, asset string) (string, string, error) {
+	if tag == "" {
+		tags, err := c.Tags()
+		if err != nil {
+			return "", "", err
+		}
+		if len(tags) == 0 {
+			return "", "", errors.New("no tags found")
+		}
+		tag = tags[0]
+	}
+
+	if asset == "" {
+		assets, err := c.Assets(tag)
+		if err != nil {
+			return "", "", err
+		}
+		if len(assets) == 0 {
+			return "", "", fmt.Errorf("no matching assets found for tag %q", tag)
+		}
+		asset = assets[0]
+	}
+
+	return tag, asset, nil
+}
+
 func (c config) Println(s string) {
 	c.Printf(s + "\n")
 }

--- a/selfupdate_test.go
+++ b/selfupdate_test.go
@@ -1,0 +1,101 @@
+package selfupdate
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+type fakeTransport struct {
+	tags   string
+	assets string
+}
+
+func (f fakeTransport) Tags(_ string, out, _ io.Writer) error {
+	_, err := io.WriteString(out, f.tags)
+	return err
+}
+
+func (f fakeTransport) Assets(_, _ string, out, _ io.Writer) error {
+	_, err := io.WriteString(out, f.assets)
+	return err
+}
+
+func (f fakeTransport) Download(_, _, _ string, _, _ io.Writer) error {
+	return nil
+}
+
+func TestResolveDefaultsTagAndAsset(t *testing.T) {
+	c := New(
+		"owner",
+		"repository",
+		WithTransport(fakeTransport{
+			tags:   `[{"name":"v2.0.0"},{"name":"v1.0.0"}]`,
+			assets: `{"assets":[{"name":"checksums.txt"},{"name":"matching-asset.tar.gz"}]}`,
+		}),
+		WithAssetFilter(func(s string) bool { return strings.HasSuffix(s, ".tar.gz") }),
+		WithProgress(io.Discard),
+	)
+
+	tag, asset, err := c.resolve("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "v2.0.0" {
+		t.Fatalf("expected latest tag, got %q", tag)
+	}
+	if asset != "matching-asset.tar.gz" {
+		t.Fatalf("expected first matching asset, got %q", asset)
+	}
+}
+
+func TestResolveKeepsProvidedTagAndAsset(t *testing.T) {
+	c := New(
+		"owner",
+		"repository",
+		WithTransport(fakeTransport{}),
+		WithProgress(io.Discard),
+	)
+
+	tag, asset, err := c.resolve("v1.0.0", "repository_v1.0.0_linux_amd64.tar.gz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "v1.0.0" {
+		t.Fatalf("expected provided tag, got %q", tag)
+	}
+	if asset != "repository_v1.0.0_linux_amd64.tar.gz" {
+		t.Fatalf("expected provided asset, got %q", asset)
+	}
+}
+
+func TestResolveErrorsWhenTagsAreEmpty(t *testing.T) {
+	c := New(
+		"owner",
+		"repository",
+		WithTransport(fakeTransport{tags: `[]`}),
+		WithProgress(io.Discard),
+	)
+
+	if _, _, err := c.resolve("", ""); err == nil || err.Error() != "no tags found" {
+		t.Fatalf("expected no tags error, got %v", err)
+	}
+}
+
+func TestResolveErrorsWhenNoAssetsMatch(t *testing.T) {
+	c := New(
+		"owner",
+		"repository",
+		WithTransport(fakeTransport{
+			tags:   `[{"name":"v1.0.0"}]`,
+			assets: `{"assets":[{"name":"checksums.txt"}]}`,
+		}),
+		WithAssetFilter(func(string) bool { return false }),
+		WithProgress(io.Discard),
+	)
+
+	_, _, err := c.resolve("", "")
+	if err == nil || !strings.Contains(err.Error(), "no matching assets found") {
+		t.Fatalf("expected no matching assets error, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #9.\n\nThis lets the selfupdate command run with only the source argument by resolving the latest tag and then selecting the first asset that matches the existing platform asset filter. Explicit tag and asset arguments keep the existing behavior.\n\nChanges:\n- relax command args from exactly source/tag/asset to source with optional tag and asset\n- validate the requested source before constructing the updater\n- resolve omitted tag and asset values through the existing GitHub tag/release asset helpers\n- add tests for implicit selection, explicit values, and empty tag/asset error cases\n\nTests:\n- ok  	github.com/carapace-sh/carapace-selfupdate	(cached)
?   	github.com/carapace-sh/carapace-selfupdate/filter	[no test files]
?   	github.com/carapace-sh/carapace-selfupdate/transport	[no test files]\n- ?   	github.com/carapace-sh/carapace-selfupdate/cmd/carapace-selfupdate	[no test files]
?   	github.com/carapace-sh/carapace-selfupdate/cmd/carapace-selfupdate/cmd	[no test files]