### PR TITLE
Verify selfupdate asset checksums

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -1,22 +1,103 @@
 package selfupdate
 
 import (
+	"bytes"
 	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
-//lint:ignore U1000 TODO
-func verify(path string) error {
+func (c config) Checksum(tag, asset string) (string, error) {
+	checksumAsset, err := c.checksumAsset(tag)
+	if err != nil {
+		return "", err
+	}
+
+	var b bytes.Buffer
+	if err := c.Download(tag, checksumAsset, &b); err != nil {
+		return "", err
+	}
+
+	return parseChecksum(b.String(), asset)
+}
+
+func (c config) checksumAsset(tag string) (string, error) {
+	unfiltered := c
+	unfiltered.filter = nil
+
+	assets, err := unfiltered.Assets(tag)
+	if err != nil {
+		return "", err
+	}
+
+	for _, asset := range assets {
+		if strings.HasSuffix(asset, "_checksums.txt") || asset == "checksums.txt" {
+			return asset, nil
+		}
+	}
+	for _, asset := range assets {
+		if strings.HasSuffix(asset, "checksums.txt") {
+			return asset, nil
+		}
+	}
+
+	return "", fmt.Errorf("checksum asset not found for tag %q", tag)
+}
+
+func parseChecksum(content, asset string) (string, error) {
+	for _, line := range strings.Split(content, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		sum := strings.ToLower(fields[0])
+		if fields[len(fields)-1] == asset && isSHA256(sum) {
+			return sum, nil
+		}
+	}
+
+	return "", fmt.Errorf("checksum for %q not found", asset)
+}
+
+func isSHA256(s string) bool {
+	if len(s) != sha256.Size*2 {
+		return false
+	}
+	_, err := hex.DecodeString(s)
+	return err == nil
+}
+
+func fileChecksum(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer f.Close()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func (c config) verifyChecksum(tag, asset, path string) error {
+	expected, err := c.Checksum(tag, asset)
+	if err != nil {
 		return err
+	}
+
+	actual, err := fileChecksum(path)
+	if err != nil {
+		return err
+	}
+
+	if actual != expected {
+		return fmt.Errorf("checksum mismatch for %q: expected %s, got %s", asset, expected, actual)
 	}
 	return nil
 }

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -1,0 +1,105 @@
+package selfupdate
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+type checksumTransport struct {
+	assets    string
+	downloads map[string]string
+}
+
+func (t checksumTransport) Tags(_ string, _, _ io.Writer) error {
+	return nil
+}
+
+func (t checksumTransport) Assets(_, _ string, out, _ io.Writer) error {
+	_, err := io.WriteString(out, t.assets)
+	return err
+}
+
+func (t checksumTransport) Download(_, _, asset string, out, _ io.Writer) error {
+	_, err := io.WriteString(out, t.downloads[asset])
+	return err
+}
+
+func TestVerifyChecksum(t *testing.T) {
+	asset := "project_1.0.0_linux_amd64.tar.gz"
+	content := "archive bytes"
+	sum := fmt.Sprintf("%x", sha256.Sum256([]byte(content)))
+	path := writeTempFile(t, content)
+
+	c := New("owner", "project", WithTransport(checksumTransport{
+		assets: fmt.Sprintf(`{"assets":[{"name":"project_1.0.0_checksums.txt"},{"name":%q}]}`, asset),
+		downloads: map[string]string{
+			"project_1.0.0_checksums.txt": fmt.Sprintf("%s  %s\n", sum, asset),
+		},
+	}))
+
+	if err := c.verifyChecksum("v1.0.0", asset, path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyChecksumMismatch(t *testing.T) {
+	asset := "project_1.0.0_linux_amd64.tar.gz"
+	path := writeTempFile(t, "archive bytes")
+
+	c := New("owner", "project", WithTransport(checksumTransport{
+		assets: fmt.Sprintf(`{"assets":[{"name":"project_1.0.0_checksums.txt"},{"name":%q}]}`, asset),
+		downloads: map[string]string{
+			"project_1.0.0_checksums.txt": strings.Repeat("0", sha256.Size*2) + "  " + asset + "\n",
+		},
+	}))
+
+	err := c.verifyChecksum("v1.0.0", asset, path)
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("expected checksum mismatch, got %v", err)
+	}
+}
+
+func TestChecksumMissingAsset(t *testing.T) {
+	c := New("owner", "project", WithTransport(checksumTransport{
+		assets: `{"assets":[{"name":"project_1.0.0_linux_amd64.tar.gz"}]}`,
+	}))
+
+	_, err := c.Checksum("v1.0.0", "project_1.0.0_linux_amd64.tar.gz")
+	if err == nil || !strings.Contains(err.Error(), "checksum asset not found") {
+		t.Fatalf("expected missing checksum asset error, got %v", err)
+	}
+}
+
+func TestChecksumMissingEntry(t *testing.T) {
+	c := New("owner", "project", WithTransport(checksumTransport{
+		assets: `{"assets":[{"name":"project_1.0.0_checksums.txt"}]}`,
+		downloads: map[string]string{
+			"project_1.0.0_checksums.txt": strings.Repeat("a", sha256.Size*2) + "  other.tar.gz\n",
+		},
+	}))
+
+	_, err := c.Checksum("v1.0.0", "project_1.0.0_linux_amd64.tar.gz")
+	if err == nil || !strings.Contains(err.Error(), "checksum for") {
+		t.Fatalf("expected missing checksum entry error, got %v", err)
+	}
+}
+
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+
+	f, err := os.CreateTemp(t.TempDir(), "archive-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(f, content); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return f.Name()
+}

--- a/command.go
+++ b/command.go
@@ -30,6 +30,9 @@ func Command(owner, repository string, opts ...option) *cobra.Command {
 				if cmd.Flag("force").Changed {
 					opts = append(opts, WithForce(true))
 				}
+				if noVerify, _ := cmd.Flags().GetBool("no-verify"); noVerify {
+					opts = append(opts, WithNoVerify(true))
+				}
 				c := New(owner, repo[args[0]], opts...)
 				return c.Install(args[1], args[2])
 			}
@@ -40,7 +43,7 @@ func Command(owner, repository string, opts ...option) *cobra.Command {
 	cmd.Flags().BoolP("all", "a", false, "show all tags/assets")
 	cmd.Flags().BoolP("force", "f", false, "force")
 	cmd.Flags().BoolP("help", "h", false, "help for selfupdate") // TODO use cobras help flag
-	// cmd.Flags().Bool("no-verify", false, "disable checksum verification") // TODO disable verification
+	cmd.Flags().Bool("no-verify", false, "disable checksum verification")
 
 	carapace.Gen(cmd).Standalone()
 

--- a/selfupdate.go
+++ b/selfupdate.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 
@@ -24,6 +23,7 @@ type config struct {
 	binary   string
 	filter   func(asset string) bool
 	force    bool
+	noVerify bool
 	progress io.Writer
 	t        transport.Transport
 }
@@ -61,6 +61,12 @@ func WithAssetFilter(f func(s string) bool) func(c *config) {
 func WithForce(b bool) func(c *config) {
 	return func(c *config) {
 		c.force = b
+	}
+}
+
+func WithNoVerify(b bool) func(c *config) {
+	return func(c *config) {
+		c.noVerify = b
 	}
 }
 
@@ -160,19 +166,23 @@ func (c config) Install(tag, asset string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
 	c.Printf("downloading to %#v\n", tmpArchive.Name())
 	if err := c.Download(tag, asset, f); err != nil {
+		_ = f.Close()
 		return err
 	}
 
-	// sum, err := c.Checksum(tag, asset)
-	// if err != nil {
-	// 	return err
-	// }
+	if err := f.Close(); err != nil {
+		return err
+	}
 
-	// TODO verify checksum
+	if !c.noVerify {
+		c.Printf("verifying checksum\n")
+		if err := c.verifyChecksum(tag, asset, tmpArchive.Name()); err != nil {
+			return err
+		}
+	}
 
 	binDir, err := traverse.GoBinDir(carapace.NewContext())
 	if err != nil {
@@ -202,7 +212,6 @@ func (c config) Install(tag, asset string) error {
 		return err
 	}
 	defer os.Remove(fExecutable.Name())
-	defer f.Close()
 
 	c.Printf("extracting to %#v\n", fExecutable.Name())
 	if err := c.extract(tmpArchive.Name(), fExecutable); err != nil {
@@ -259,25 +268,4 @@ func (c config) extract(source string, out io.Writer) error {
 
 func (c config) Download(tag, asset string, out io.Writer) error {
 	return c.t.Download(c.repo, tag, asset, out, c.progress)
-}
-
-func (c config) Checksum(tag, asset string) (string, error) {
-	r := regexp.MustCompile(`^(?P<prefix>[^_]+_[^_]+)_.*$`)
-	matches := r.FindStringSubmatch(asset)
-	if matches == nil {
-		return "", errors.New(`asset does not match checksum pattern`)
-	}
-
-	b := &bytes.Buffer{}
-	if err := c.t.Download(c.repo, tag, fmt.Sprintf("%v_checksums.txt", matches[1]), b, c.progress); err != nil {
-		return "", err
-	}
-
-	m := make(map[string]string)
-	for _, line := range strings.Split(b.String(), "\n") {
-		if sum, file, ok := strings.Cut(line, "  "); ok {
-			m[file] = sum
-		}
-	}
-	return m[asset], nil
 }


### PR DESCRIPTION
Closes #4.

This verifies downloaded release archives against the release checksum file before extraction, with `--no-verify` available to keep the requested escape hatch.

Changes:
- add `--no-verify` and `WithNoVerify` support
- close the downloaded archive before reading it back for checksum verification/extraction
- find the release checksum asset from the unfiltered release asset list
- parse GoReleaser-style `sha256  filename` entries
- compare the downloaded archive SHA-256 before extraction
- add tests for successful verification, mismatch, missing checksum asset, and missing checksum entry

Validation:
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./cmd/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go build ./cmd/carapace-selfupdate`
- `git diff --check`
