### PR TITLE
Filter selfupdate tag completions by version

### DIFF
--- a/command.go
+++ b/command.go
@@ -54,9 +54,13 @@ func Command(owner, repository string, opts ...option) *cobra.Command {
 			if cmd.Flag("all").Changed {
 				opts = append(opts, WithAssetFilter(nil))
 			}
-			tags, err := New(owner, repo[c.Args[0]], opts...).Tags()
+			updater := New(owner, repo[c.Args[0]], opts...)
+			tags, err := updater.Tags()
 			if err != nil {
 				return carapace.ActionMessage(err.Error())
+			}
+			if !cmd.Flag("all").Changed {
+				tags = updater.newerTags(tags)
 			}
 			return carapace.ActionValues(tags...)
 		}),

--- a/version.go
+++ b/version.go
@@ -1,0 +1,94 @@
+package selfupdate
+
+import (
+	"errors"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type version struct {
+	major int
+	minor int
+	patch int
+}
+
+func (c config) newerTags(tags []string) []string {
+	current, err := c.currentVersion()
+	if err != nil {
+		return tags
+	}
+	return filterNewerTags(tags, current)
+}
+
+func (c config) currentVersion() (string, error) {
+	b, err := exec.Command(c.binary, "--version").Output()
+	if err != nil {
+		return "", err
+	}
+
+	for _, field := range strings.Fields(string(b)) {
+		if _, ok := parseVersion(field); ok {
+			return field, nil
+		}
+	}
+	return "", errors.New("current version not found")
+}
+
+func filterNewerTags(tags []string, current string) []string {
+	currentVersion, ok := parseVersion(current)
+	if !ok {
+		return tags
+	}
+
+	filtered := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		tagVersion, ok := parseVersion(tag)
+		if !ok {
+			continue
+		}
+		if compareVersion(tagVersion, currentVersion) > 0 {
+			filtered = append(filtered, tag)
+		}
+	}
+	return filtered
+}
+
+func parseVersion(s string) (version, bool) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+	if i := strings.IndexAny(s, "-+"); i != -1 {
+		s = s[:i]
+	}
+
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return version{}, false
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return version{}, false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return version{}, false
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return version{}, false
+	}
+
+	return version{major: major, minor: minor, patch: patch}, true
+}
+
+func compareVersion(a, b version) int {
+	switch {
+	case a.major != b.major:
+		return a.major - b.major
+	case a.minor != b.minor:
+		return a.minor - b.minor
+	default:
+		return a.patch - b.patch
+	}
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,47 @@
+package selfupdate
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFilterNewerTags(t *testing.T) {
+	tags := []string{"v1.7.0", "v1.6.6", "v1.6.5", "v1.6.4", "nightly"}
+	got := filterNewerTags(tags, "1.6.5")
+	want := []string{"v1.7.0", "v1.6.6"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestFilterNewerTagsKeepsAllWhenCurrentVersionIsUnknown(t *testing.T) {
+	tags := []string{"v1.7.0", "v1.6.5"}
+	got := filterNewerTags(tags, "develop")
+
+	if !reflect.DeepEqual(got, tags) {
+		t.Fatalf("expected %v, got %v", tags, got)
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	got, ok := parseVersion("v1.2.3")
+	if !ok {
+		t.Fatal("expected version to parse")
+	}
+	want := version{major: 1, minor: 2, patch: 3}
+	if got != want {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestParseVersionWithPrerelease(t *testing.T) {
+	got, ok := parseVersion("1.2.3-beta.1")
+	if !ok {
+		t.Fatal("expected version to parse")
+	}
+	want := version{major: 1, minor: 2, patch: 3}
+	if got != want {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}


### PR DESCRIPTION
Closes #6.

This filters tag completions to versions newer than the installed target binary, while keeping the existing `--all` escape hatch. If the installed binary is missing or does not report a comparable semver version, completions fall back to the unfiltered tag list.

Changes:
- detect the current installed binary version from `<binary> --version`
- parse `vMAJOR.MINOR.PATCH`/`MAJOR.MINOR.PATCH` tags
- filter tag completion results to tags newer than the current version
- leave `--all` behavior unfiltered
- add parser and filtering tests

Validation:
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./cmd/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go build ./cmd/carapace-selfupdate`
- `git diff --check`
